### PR TITLE
include concat-stream dependency

### DIFF
--- a/georsstogeojson
+++ b/georsstogeojson
@@ -2,7 +2,6 @@
 
 var t = require('./GeoRSSToGeoJSON').GeoRSSToGeoJSON,
     args = process.argv.slice(2),
-    concat = require('concat-stream'),
     fs = require('fs'),
     xmldom = new (require('xmldom').DOMParser)();
 if (args.length != 1) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "From GeoRSS to GeoJSON",
   "main": "GeoRSSToGeoJSON.js",
   "dependencies": {
-    "xmldom": "~0.1.19"
+    "xmldom": "~0.1.19",
+    "concat-stream": "^1.6.0"    
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "From GeoRSS to GeoJSON",
   "main": "GeoRSSToGeoJSON.js",
   "dependencies": {
-    "xmldom": "~0.1.19",
-    "concat-stream": "^1.6.0"    
+    "xmldom": "~0.1.19"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This module is used by the code but not included in the dependencies.

```
Error: Cannot find module 'concat-stream'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/tmp/test/node_modules/georsstogeojson/georsstogeojson:5:14)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```
  